### PR TITLE
fix: Nil method fails on nil pointer

### DIFF
--- a/ensure.go
+++ b/ensure.go
@@ -178,7 +178,7 @@ func Nil(t Fataler, v interface{}, a ...interface{}) {
 		sp = "\n"
 	}
 
-	if v != nil {
+	if v != nil && !reflect.ValueOf(v).IsNil() {
 		// Special case errors for prettier output.
 		if _, ok := v.(error); ok {
 			fatal(cond{

--- a/ensure_test.go
+++ b/ensure_test.go
@@ -250,3 +250,12 @@ ACTUAL:
 foo
 baz`)
 }
+
+func TestNilPointer(t *testing.T) {
+	foo := func() map[string]int {
+		var m map[string]int // m == nil
+		return m
+	}
+	m := foo()
+	ensure.Nil(t, m)
+}


### PR DESCRIPTION
When I test function like: 
```go 
func foo() map[string]*Foo{
   // ...
}
```
it returns a map, the value of some keys are nil, and Nil method fails on that case since Nil take interface{} as parameter, which make nil-check inaccurate. See [nil_error](https://golang.org/doc/faq#nil_error)
